### PR TITLE
Put Mailchimp form into its own HTML file

### DIFF
--- a/html/subscribeForm.js
+++ b/html/subscribeForm.js
@@ -1,0 +1,38 @@
+module.exports = `
+<!-- Begin Mailchimp Signup Form -->
+<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+	/* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
+	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+</style>
+<div id="mc_embed_signup">
+<form action="https://luciakempkes.us3.list-manage.com/subscribe/post?u=5d18b57e2faae98718bb96d36&amp;id=54af65277c" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+	<h5>Subscribe to the newsletter for upcoming shows and events</h5>
+<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+<div class="mc-field-group">
+	<label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
+</label>
+	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+</div>
+<div class="mc-field-group">
+	<label for="mce-FNAME">First Name </label>
+	<input type="text" value="" name="FNAME" class="" id="mce-FNAME">
+</div>
+<div class="mc-field-group">
+	<label for="mce-LNAME">Last Name </label>
+	<input type="text" value="" name="LNAME" class="" id="mce-LNAME">
+</div>
+	<div id="mce-responses" class="clear">
+		<div class="response" id="mce-error-response" style="display:none"></div>
+		<div class="response" id="mce-success-response" style="display:none"></div>
+	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_5d18b57e2faae98718bb96d36_54af65277c" tabindex="-1" value=""></div>
+    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+    </div>
+</form>
+</div>
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='MMERGE3';ftypes[3]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<!--End mc_embed_signup-->
+`;

--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -8,6 +8,9 @@ import Header from '../components/header'
 import Layout from '../components/layout'
 import Body from '../components/body'
 import AnimateElement from '../components/AnimateElement';
+
+import __subscribeForm from '../html/subscribeForm';
+
 import { getPage, getFooter, getHomepageProjectSlugs, getAllPagesWithSlug } from '../lib/api'
 import { CMS_NAME } from '../lib/constants'
 
@@ -24,6 +27,8 @@ export default function Page({ page, previousPageSlug, nextPageSlug, parentPageS
   }
 
   const today = new Date();
+
+  const subscribeFormHTML = { __html: __subscribeForm };
 
   return (
     <Layout
@@ -74,6 +79,9 @@ export default function Page({ page, previousPageSlug, nextPageSlug, parentPageS
                   id={router.asPath}
                   className="grid-widescreen-center"
                 >
+                  { page.slug === "subscribe" &&
+                    <div className={styles.subscribeForm} dangerouslySetInnerHTML={subscribeFormHTML} />
+                  }
                   <Body body={page.body} />
                 </AnimateElement>
                 <div className="grid-widescreen-right"></div>

--- a/pages/[slug].module.scss
+++ b/pages/[slug].module.scss
@@ -2,6 +2,16 @@
   text-align: center;
 }
 
+.subscribeForm {
+  border: 1px solid var(--neutral-color);
+  margin-bottom: 1rem;
+
+  @media screen and (max-width: 700px) {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+}
+
 .bodyFooter {
   border-top: 1px solid var(--accent-color);
   text-align: center;

--- a/styles/base.scss
+++ b/styles/base.scss
@@ -115,6 +115,17 @@ img, video {
   display: block;
 }
 
+/* Styling Mailchimp Form */
+label, input {
+  font-family: var(--header-font);
+  font-size: inherit;
+}
+
+.indicates-required {
+  font-family: var(--body-font);
+}
+/* */
+
 .content {
   position: relative;
   z-index: 1; /* For the background grid lines on mobile */


### PR DESCRIPTION
We simply export it, then use `dangerouslySetInnerHTML`. This allows us to not have to turn the form HTML itself into valid JSX, while at the same time not requiring `browserify` or `stringify` to be able to import actual `.html` files. This is an easy in-between, while unfortunately Contentful doesn't seem to support users inputting HTML into the admin.